### PR TITLE
fix: Adiciona Procfile e gunicorn para o deploy

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: gunicorn run:app

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ Flask-SQLAlchemy
 Flask-JWT-Extended
 python-dotenv
 openpyxl
+gunicorn


### PR DESCRIPTION
Adiciona o gunicorn como dependência e cria um Procfile para especificar o comando de inicialização da aplicação. Isso corrige o erro de 'No start command could be found' que ocorria durante o deploy na plataforma Nixpacks.