### PR TITLE
fix: Correct pip command for Railway deployment

### DIFF
--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -6,7 +6,8 @@ nixPkgs = ["python312"]
 
 [phases.install]
 # Command to install dependencies from requirements.txt
-cmds = ["pip install --upgrade pip && pip install -r requirements.txt"]
+# Using "python -m pip" is more robust in some environments
+cmds = ["python -m pip install --upgrade pip", "python -m pip install -r requirements.txt"]
 
 [start]
 # Command to start the application with Gunicorn


### PR DESCRIPTION
This commit fixes a deployment failure on Railway where the `pip` command was not found.

The install command in `nixpacks.toml` has been changed from `pip install` to `python -m pip install`. This is a more robust way to invoke pip in containerized and Nix-based environments, as it does not rely on the shell's PATH.

This should resolve the final deployment issue.