### PR TITLE
fix: Correct SQLAlchemy package dependency in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Flask
-SQLAlchemy
+Flask-SQLAlchemy
 psycopg2-binary
 Flask-Login
 python-dotenv


### PR DESCRIPTION
This commit fixes a runtime failure where the application would not start due to the error "ModuleNotFoundError: No module named 'flask_sqlalchemy'".

This was caused by having the wrong package name in `requirements.txt`. The application uses the `Flask-SQLAlchemy` wrapper, but the dependency was listed as `SQLAlchemy`.

The `requirements.txt` file has been corrected to include `Flask-SQLAlchemy`. This ensures the correct package is installed during the build process, allowing the application to import the necessary module and start successfully.