### PR TITLE
fix: Handle null dates in dashboard API

### DIFF
--- a/app.py
+++ b/app.py
@@ -623,7 +623,7 @@ def dashboard_data():
     status_protocolos = db.session.query(Protocolo.status, func.count(Protocolo.id).label('total')).select_from(base_query.subquery()).group_by(Protocolo.status).order_by(Protocolo.status).all()
 
     # Evolution Chart Logic
-    evolucao_query = Protocolo.query
+    evolucao_query = Protocolo.query.filter(Protocolo.data_solicitacao.isnot(None)) # Add filter for non-null dates
     if evolucao_periodo == '7d':
         evolucao_query = evolucao_query.filter(Protocolo.data_solicitacao >= (datetime.now().date() - timedelta(days=7)))
     elif evolucao_periodo == '30d':


### PR DESCRIPTION
This commit fixes a runtime `AttributeError: 'NoneType' object has no attribute 'isoformat'` in the `/api/dashboard-data` route.

The error was caused by the evolution chart query attempting to process `Protocolo` records with a null `data_solicitacao`.

The fix adds a `.filter(Protocolo.data_solicitacao.isnot(None))` to the query to ensure only records with valid dates are processed, making the API more robust.

This resolves the final known runtime error.