### PR TITLE
Hotfix: Corrige erro crítico que impedia a inicialização da aplicação

### DIFF
--- a/templates/layout.html
+++ b/templates/layout.html
@@ -44,15 +44,11 @@
     {% endif %}
 
     <main class="main-content">
-        {# On the login page, the content block is the full page #}
-        {# On other pages, it's inside a container #}
-        {% if request.endpoint != 'login' %}
-            <div class="container-fluid mt-4">
-                {% block content %}{% endblock %}
-            </div>
-        {% else %}
+        {# On the login page, the content block is not wrapped in a container #}
+        {# On other pages, it is. This structure avoids defining the block twice. #}
+        <div class="{% if request.endpoint != 'login' %}container-fluid mt-4{% endif %}">
             {% block content %}{% endblock %}
-        {% endif %}
+        </div>
     </main>
 
     <!-- Bootstrap JS Bundle -->


### PR DESCRIPTION
Este commit corrige um erro fatal no template `layout.html` que causava um `TemplateAssertionError: block 'content' defined twice`. Este erro impedia a aplicação de iniciar corretamente.

Adicionalmente, este commit inclui as alterações anteriores que restauram a funcionalidade e modernizam a interface:
- Geração automática do número de protocolo no formato NNNN/ANO.
- Correção da página de criação de protocolo para reativar o JavaScript.
- Reformulação visual completa da página de login, layout principal, tabelas e botões.