### PR TITLE
Corrige o botão de busca na página de novo protocolo que não abria o …

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -459,9 +459,12 @@ function initializeProtocolForm() {
     document.getElementById('cep').addEventListener('blur', fetchCep);
 
     // This was the fix for the search button, which I am also restoring.
-    const btnBuscarNome = document.getElementById('btnBuscarNome');
-    if (btnBuscarNome) {
-        btnBuscarNome.addEventListener('click', openServidorSearchModal);
+    const searchModal = document.getElementById('modalBuscaServidor');
+    if(searchModal) {
+        searchModal.addEventListener('show.bs.modal', function() {
+            document.getElementById('buscaNomeInput').value = '';
+            document.getElementById('buscaNomeResultados').innerHTML = '';
+        });
     }
 
     const buscaInput = document.getElementById('buscaNomeInput');
@@ -639,15 +642,6 @@ function preencherCamposServidor(servidor) {
     }
 }
 
-function openServidorSearchModal() {
-    const modalElement = document.getElementById('modalBuscaServidor');
-    if (modalElement) {
-        const modal = new bootstrap.Modal(modalElement);
-        document.getElementById('buscaNomeInput').value = '';
-        document.getElementById('buscaNomeResultados').innerHTML = '';
-        modal.show();
-    }
-}
 
 async function searchServidorByName() {
     const searchTerm = this.value.trim();

--- a/templates/criar_protocolo.html
+++ b/templates/criar_protocolo.html
@@ -26,7 +26,7 @@
             <input type="text" id="nome" name="nome" class="form-control" value="{{ protocolo.nome if protocolo else '' }}">
         </div>
         <div class="form-group span-1" style="justify-content: flex-end; align-items: flex-end;">
-            <button type="button" id="btnBuscarNome" class="btn btn-secondary" style="width: 100%; height: 38px;">Buscar</button>
+            <button type="button" id="btnBuscarNome" class="btn btn-secondary" style="width: 100%; height: 38px;" data-bs-toggle="modal" data-bs-target="#modalBuscaServidor">Buscar</button>
         </div>
         <div class="form-group span-6">
             <label for="endereco">Endereço</label>


### PR DESCRIPTION
…modal de busca de servidor.

A correção adota a abordagem declarativa do Bootstrap para acionar o modal, que é mais robusta:
- Adiciona os atributos `data-bs-toggle` e `data-bs-target` ao botão no HTML.
- Remove o código JavaScript antigo que tentava abrir o modal programaticamente.
- Adiciona um novo ouvinte de evento para o evento `show.bs.modal` para limpar os campos de busca sempre que o modal é aberto, mantendo a funcionalidade de forma mais confiável.