### PR TITLE
Fix: Corrige botão de busca de servidor que não abria o modal

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -56,12 +56,6 @@ document.addEventListener('DOMContentLoaded', function () {
     // --- Delegated Event Listeners ---
     // Use event delegation for buttons that might be on any page.
     // This is more robust than attaching listeners directly in some cases.
-    document.addEventListener('click', function(e) {
-        // Delegated listener for the server search modal button
-        if (e.target && e.target.id === 'btnBuscarNome') {
-            openServidorSearchModal();
-        }
-    });
 });
 
 // --- NEW DASHBOARD FUNCTIONS ---
@@ -467,7 +461,11 @@ function initializeProtocolForm() {
     document.getElementById('matricula').addEventListener('blur', fetchServidorByMatricula);
     document.getElementById('cep').addEventListener('blur', fetchCep);
 
-    // Event listener for the search button is now handled by delegation in the main DOMContentLoaded listener.
+    // Attach listener for the server search button directly
+    const btnBuscarNome = document.getElementById('btnBuscarNome');
+    if (btnBuscarNome) {
+        btnBuscarNome.addEventListener('click', openServidorSearchModal);
+    }
 
     const buscaInput = document.getElementById('buscaNomeInput');
     if (buscaInput) {

--- a/templates/criar_protocolo.html
+++ b/templates/criar_protocolo.html
@@ -26,7 +26,7 @@
             <input type="text" id="nome" name="nome" class="form-control" value="{{ protocolo.nome if protocolo else '' }}">
         </div>
         <div class="form-group span-1" style="justify-content: flex-end; align-items: flex-end;">
-            <button type="button" id="btnBuscarNome" class="btn btn-secondary" style="width: 100%; height: 38px;" data-bs-toggle="modal" data-bs-target="#modalBuscaServidor">Buscar</button>
+            <button type="button" id="btnBuscarNome" class="btn btn-secondary" style="width: 100%; height: 38px;">Buscar</button>
         </div>
         <div class="form-group span-6">
             <label for="endereco">Endereço</label>


### PR DESCRIPTION
O botão "Buscar" na página de criação de protocolo não estava abrindo o modal de busca de servidor devido a um conflito entre os atributos 'data-bs-*' do Bootstrap e um listener de evento JavaScript customizado.

Esta correção resolve o problema da seguinte forma:
- Remove os atributos 'data-bs-toggle' e 'data-bs-target' do botão no arquivo criar_protocolo.html.
- Refatora o script.js para registrar o listener de clique diretamente no botão, em vez de usar um listener delegado no documento, tornando o código mais claro.

Com esta alteração, o botão agora abre o modal corretamente, permitindo que o usuário utilize a funcionalidade de busca de servidor, que já estava implementada no backend.