### PR TITLE
Fix: Corrige botão de busca que não abria modal

### DIFF
--- a/templates/criar_protocolo.html
+++ b/templates/criar_protocolo.html
@@ -106,6 +106,30 @@
             <a href="{{ url_for('home') }}" class="btn btn-secondary">Voltar</a>
         </div>
     </form>
+
+    <!-- Modal Busca Servidor -->
+    <div class="modal fade" id="modalBuscaServidor" tabindex="-1" aria-labelledby="modalBuscaServidorLabel" aria-hidden="true">
+      <div class="modal-dialog modal-lg">
+        <div class="modal-content">
+          <div class="modal-header">
+            <h5 class="modal-title" id="modalBuscaServidorLabel">Buscar Servidor por Nome</h5>
+            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+          </div>
+          <div class="modal-body">
+            <div class="mb-3">
+              <label for="buscaNomeInput" class="form-label">Nome do Servidor</label>
+              <input type="text" class="form-control" id="buscaNomeInput" placeholder="Digite para buscar...">
+            </div>
+            <div id="buscaNomeResultados" class="list-group">
+              <!-- Search results will appear here -->
+            </div>
+          </div>
+          <div class="modal-footer">
+            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Fechar</button>
+          </div>
+        </div>
+      </div>
+    </div>
 </div>
 {% endblock %}
 
@@ -124,27 +148,3 @@ window.protocoloData = {
 {% endif %}
 </script>
 {% endblock %}
-
-<!-- Modal Busca Servidor -->
-<div class="modal fade" id="modalBuscaServidor" tabindex="-1" aria-labelledby="modalBuscaServidorLabel" aria-hidden="true">
-  <div class="modal-dialog modal-lg">
-    <div class="modal-content">
-      <div class="modal-header">
-        <h5 class="modal-title" id="modalBuscaServidorLabel">Buscar Servidor por Nome</h5>
-        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-      </div>
-      <div class="modal-body">
-        <div class="mb-3">
-          <label for="buscaNomeInput" class="form-label">Nome do Servidor</label>
-          <input type="text" class="form-control" id="buscaNomeInput" placeholder="Digite para buscar...">
-        </div>
-        <div id="buscaNomeResultados" class="list-group">
-          <!-- Search results will appear here -->
-        </div>
-      </div>
-      <div class="modal-footer">
-        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Fechar</button>
-      </div>
-    </div>
-  </div>
-</div>


### PR DESCRIPTION
Este commit corrige um bug onde o botão "Buscar" na página de novo protocolo não abria o modal de busca de servidor.

As seguintes alterações foram feitas:
1.  Em 'criar_protocolo.html', os atributos 'data-bs-*' foram removidos do botão para evitar conflitos com o JavaScript.
2.  Em 'script.js', o listener de evento foi refatorado para ser anexado diretamente ao botão, melhorando a clareza do código.
3.  Em 'criar_protocolo.html', o HTML do modal foi movido para dentro do bloco de conteúdo do Jinja2, garantindo que ele seja renderizado na página.

Com essas correções, o botão agora funciona como esperado.